### PR TITLE
fix: move react(-dom) to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,10 +34,6 @@
   "name": "react-abode",
   "author": "Bram Kaashoek",
   "module": "dist/react-abode.esm.js",
-  "dependencies": {
-    "react": ">=16",
-    "react-dom": ">=16"
-  },
   "devDependencies": {
     "@types/react": "^16.9.23",
     "@types/react-dom": "^16.9.5",
@@ -47,6 +43,10 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.0.0",
     "typescript": "^3.9.7"
+  },
+  "peerDependencies": {
+    "react": ">=16",
+    "react-dom": ">=16"
   },
   "resolutions": {
     "serialize-javascript": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "fast-check": "^2.13.0",
     "husky": "^4.2.5",
     "mutationobserver-shim": "^0.3.7",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "tsdx": "^0.14.1",
     "tslib": "^2.0.0",
     "typescript": "^3.9.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5095,7 +5095,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-react-dom@>=16:
+react-dom@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
   integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
@@ -5109,7 +5109,7 @@ react-is@^16.12.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@>=16:
+react@^17.0.1:
   version "17.0.1"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
   integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==


### PR DESCRIPTION
Moves `react` and `react-dom` to peerDependencies to limit bundle size for this specific package (It requires you to have react installed anyways).﻿
