### PR TITLE
Limit json parsing to objects and arrays

### DIFF
--- a/src/abode.ts
+++ b/src/abode.ts
@@ -80,9 +80,14 @@ export const getElementProps = (el: Element | HTMLScriptElement): Props => {
       attribute.name.startsWith('data-prop-')
     );
     rawProps.forEach(prop => {
-      try {
-        props[getCleanPropName(prop.name)] = JSON.parse(prop.value);
-      } catch (e) {
+      const arrayOrObjRegex = /[({.*})(\[.*\])]/;
+      if (arrayOrObjRegex.test(prop.value)) {
+        try {
+          props[getCleanPropName(prop.name)] = JSON.parse(prop.value);
+        } catch (e) {
+          console.error('Could not parse JSON');
+        }
+      } else {
         props[getCleanPropName(prop.name)] = prop.value;
       }
     });

--- a/test/abode.test.tsx
+++ b/test/abode.test.tsx
@@ -63,10 +63,8 @@ describe('helper functions', () => {
     const abodeElement = document.createElement('div');
     abodeElement.setAttribute('data-component', 'TestComponent');
     abodeElement.setAttribute('data-prop-test-prop', 'testPropValue');
-    abodeElement.setAttribute('data-prop-number-prop', '12345');
-    abodeElement.setAttribute('data-prop-null-prop', 'null');
-    abodeElement.setAttribute('data-prop-true-prop', 'true');
     abodeElement.setAttribute('data-prop-empty-prop', '');
+    abodeElement.setAttribute('data-prop-array-prop', '[null]');
     abodeElement.setAttribute(
       'data-prop-json-prop',
       '{"id": 12345, "product": "keyboard", "variant": {"color": "blue"}}'
@@ -76,21 +74,27 @@ describe('helper functions', () => {
 
     expect(props).toEqual({
       testProp: 'testPropValue',
-      numberProp: 12345,
-      nullProp: null,
-      trueProp: true,
       emptyProp: '',
+      arrayProp: [null],
       jsonProp: { id: 12345, product: 'keyboard', variant: { color: 'blue' } },
     });
   });
-  it('getElementProps parses JSON', () => {
+  it('getElementProps parses JSON if attribute is object or array', () => {
+    const isArrayOrObj = (t: unknown) =>
+      Array.isArray(t) || (typeof t === 'object' && t !== null);
     fc.assert(
-      fc.property(fc.jsonObject({ maxDepth: 10 }), data => {
-        const abodeElement = document.createElement('div');
-        abodeElement.setAttribute('data-prop-test-prop', JSON.stringify(data));
-        const props = getElementProps(abodeElement);
-        expect(props.testProp).toEqual(data);
-      })
+      fc.property(
+        fc.jsonObject({ maxDepth: 10 }).filter(isArrayOrObj),
+        data => {
+          const abodeElement = document.createElement('div');
+          abodeElement.setAttribute(
+            'data-prop-test-prop',
+            JSON.stringify(data)
+          );
+          const props = getElementProps(abodeElement);
+          expect(props.testProp).toEqual(data);
+        }
+      )
     );
   });
 


### PR DESCRIPTION
 - all attributes are strings and treated as such in existing React components

 - parsing each attribute as JSON will change the attribute's type (e.g. "1234" will become 1234)

 - to ensure backward compatibility only arrays or objects are parsed as JSON