### PR TITLE
Limit json parsing

### DIFF
--- a/src/abode.ts
+++ b/src/abode.ts
@@ -80,9 +80,14 @@ export const getElementProps = (el: Element | HTMLScriptElement): Props => {
       attribute.name.startsWith('data-prop-')
     );
     rawProps.forEach(prop => {
-      try {
-        props[getCleanPropName(prop.name)] = JSON.parse(prop.value);
-      } catch (e) {
+      const arrayOrObjRegex = /[({.*})(\[.*\])]/;
+      if (arrayOrObjRegex.test(prop.value)) {
+        try {
+          props[getCleanPropName(prop.name)] = JSON.parse(prop.value);
+        } catch (e) {
+          console.error('Could not parse JSON');
+        }
+      } else {
         props[getCleanPropName(prop.name)] = prop.value;
       }
     });

--- a/src/abode.ts
+++ b/src/abode.ts
@@ -80,7 +80,7 @@ export const getElementProps = (el: Element | HTMLScriptElement): Props => {
       attribute.name.startsWith('data-prop-')
     );
     rawProps.forEach(prop => {
-      const arrayOrObjRegex = /[({.*})(\[.*\])]/;
+      const arrayOrObjRegex = /^{.*}$|^\[.*\]$/;
       if (arrayOrObjRegex.test(prop.value)) {
         try {
           props[getCleanPropName(prop.name)] = JSON.parse(prop.value);

--- a/test/abode.test.tsx
+++ b/test/abode.test.tsx
@@ -65,6 +65,9 @@ describe('helper functions', () => {
     abodeElement.setAttribute('data-prop-test-prop', 'testPropValue');
     abodeElement.setAttribute('data-prop-empty-prop', '');
     abodeElement.setAttribute('data-prop-array-prop', '[null]');
+    abodeElement.setAttribute('data-prop-path-prop', '/index.html');
+    abodeElement.setAttribute('data-prop-opening-brackets-prop', '{...[[');
+    abodeElement.setAttribute('data-prop-closing-brackets-prop', '}}}]]');
     abodeElement.setAttribute(
       'data-prop-json-prop',
       '{"id": 12345, "product": "keyboard", "variant": {"color": "blue"}}'
@@ -76,8 +79,35 @@ describe('helper functions', () => {
       testProp: 'testPropValue',
       emptyProp: '',
       arrayProp: [null],
+      pathProp: '/index.html',
+      openingBracketsProp: '{...[[',
+      closingBracketsProp: '}}}]]',
       jsonProp: { id: 12345, product: 'keyboard', variant: { color: 'blue' } },
     });
+  });
+  it('getElementProps does not parse attributes as JSON if they are not an object or an array', () => {
+    const isArrayOrObj = (t: string) => {
+      return !/^[.*]$|^{.*}$/.test(t);
+    };
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 3, maxLength: 25 }).filter(isArrayOrObj),
+        fc.webUrl(),
+        fc.emailAddress(),
+        (str, url, email) => {
+          const abodeElement = document.createElement('div');
+          abodeElement.setAttribute('data-prop-str-prop', str);
+          abodeElement.setAttribute('data-prop-url-prop', url);
+          abodeElement.setAttribute('data-prop-email-prop', email);
+          const props = getElementProps(abodeElement);
+          expect(props).toEqual({
+            strProp: str,
+            urlProp: url,
+            emailProp: email,
+          });
+        }
+      )
+    );
   });
   it('getElementProps parses JSON if attribute is object or array', () => {
     const isArrayOrObj = (t: unknown) =>

--- a/test/abode.test.tsx
+++ b/test/abode.test.tsx
@@ -63,10 +63,8 @@ describe('helper functions', () => {
     const abodeElement = document.createElement('div');
     abodeElement.setAttribute('data-component', 'TestComponent');
     abodeElement.setAttribute('data-prop-test-prop', 'testPropValue');
-    abodeElement.setAttribute('data-prop-number-prop', '12345');
-    abodeElement.setAttribute('data-prop-null-prop', 'null');
-    abodeElement.setAttribute('data-prop-true-prop', 'true');
     abodeElement.setAttribute('data-prop-empty-prop', '');
+    abodeElement.setAttribute('data-prop-array-prop', '[null]');
     abodeElement.setAttribute(
       'data-prop-json-prop',
       '{"id": 12345, "product": "keyboard", "variant": {"color": "blue"}}'
@@ -76,21 +74,27 @@ describe('helper functions', () => {
 
     expect(props).toEqual({
       testProp: 'testPropValue',
-      numberProp: 12345,
-      nullProp: null,
-      trueProp: true,
       emptyProp: '',
+      arrayProp: [null],
       jsonProp: { id: 12345, product: 'keyboard', variant: { color: 'blue' } },
     });
   });
-  it('getElementProps parses JSON', () => {
+  it('getElementProps parses JSON if attribute is object or array', () => {
+    const isArrayOrObj = (t: unknown) =>
+      Array.isArray(t) || (typeof t === 'object' && t !== null);
     fc.assert(
-      fc.property(fc.jsonObject({ maxDepth: 10 }), data => {
-        const abodeElement = document.createElement('div');
-        abodeElement.setAttribute('data-prop-test-prop', JSON.stringify(data));
-        const props = getElementProps(abodeElement);
-        expect(props.testProp).toEqual(data);
-      })
+      fc.property(
+        fc.jsonObject({ maxDepth: 10 }).filter(isArrayOrObj),
+        data => {
+          const abodeElement = document.createElement('div');
+          abodeElement.setAttribute(
+            'data-prop-test-prop',
+            JSON.stringify(data)
+          );
+          const props = getElementProps(abodeElement);
+          expect(props.testProp).toEqual(data);
+        }
+      )
     );
   });
 


### PR DESCRIPTION
 - all attributes are strings and treated as such in existing React components

 - parsing each attribute as JSON will change the attribute's type (e.g. "1234" will become 1234)

 - to ensure backward compatibility only arrays or objects are parsed as JSON