### PR TITLE
refactor: update github build for pnpm, build emit esm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,35 +8,41 @@ jobs:
       - name: Begin CI...
         uses: actions/checkout@v2
 
-      - name: Use Node 12
+      - name: Use Node 16
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
 
-      - name: Use cached node_modules
-        uses: actions/cache@v1
+      # - name: Use cached node_modules
+      #   uses: actions/cache@v1
+      #   with:
+      #     path: node_modules
+      #     key: nodeModules-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       nodeModules-
+
+      - uses: pnpm/action-setup@v2.2.2
+        name: Install pnpm
+        id: pnpm-install
         with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            nodeModules-
+          version: 7.5.2
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: pnpm install
         env:
           CI: true
 
       - name: Lint
-        run: yarn lint
+        run: pnpm lint
         env:
           CI: true
 
       - name: Test
-        run: yarn test --ci --coverage --maxWorkers=2
+        run: pnpm test
         env:
           CI: true
 
       - name: Build
-        run: yarn build
+        run: pnpm build
         env:
           CI: true

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "tsup ./src/index.ts --dts --watch",
-    "build": "tsup ./src/index.ts --dts",
+    "build": "tsup ./src/index.ts --dts --sourcemap --format esm,cjs",
     "changeset": "pnpm exec changeset",
     "get:changes": "git log --format=%B --no-merges HEAD  ^master | pbcopy",
     "husky:install": "pnpm exec husky install",
@@ -34,7 +34,7 @@
   },
   "name": "react-abode",
   "author": "Bram Kaashoek",
-  "module": "dist/react-abode.esm.js",
+  "module": "dist/index.mjs",
   "devDependencies": {
     "@changesets/cli": "^2.24.2",
     "@types/jest": "^28.1.6",


### PR DESCRIPTION
Update github action to work with the pnpm changes
+ Sync node version to package.json ver (16)
+ Adjust build to emit sourcemap and esm build artifacts